### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,7 @@
 ## Setup
 
 ```bash
-# pnpm
-pnpm add -D nuxt-fathom
-
-# npm
-npm i -D nuxt-fathom
-
-# yarn
-yarn add -D nuxt-fathom
+npx nuxi@latest module add fathom-analytics
 ```
 
 ## Basic Usage

--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@
 - 🦾 SSR-ready
 - 📂 [`.env` file support](#configuration)
 
-## Setup
+## Installation
+
+Running the following command will:
+
+- Install the module as a dependency using your package manager.
+- Add it to your `package.json` file.
+- Update your `nuxt.config` file.
 
 ```bash
 npx nuxi@latest module add fathom-analytics
@@ -25,7 +31,7 @@ npx nuxi@latest module add fathom-analytics
 
 ## Basic Usage
 
-Add `nuxt-fathom` to the `modules` section of your Nuxt configuration and provide your Fathom site ID.
+Provide your Fathom site ID in your `nuxt.config` file.
 
 ```ts
 // `nuxt.config.ts`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
