### PR TITLE
fix: force `trackPageview` to track the destination URL

### DIFF
--- a/src/runtime/plugin.client.ts
+++ b/src/runtime/plugin.client.ts
@@ -22,7 +22,7 @@ export default defineNuxtPlugin(() => {
     watch(
       () => route.path,
       () => {
-        trackPageview();
+        trackPageview({ url: route.fullPath });
       }
     );
   }


### PR DESCRIPTION
Seems like `trackPageview` is tracking the "old" path instead of the new visited url. I was having a hard time matching the Fathom dashboard visitor URL and my app current URL, it was always one route behind. Unsure if this comes from the `fathom-client` library or their own

When the script is loaded it tracks the initial URL `/`:

<img width="934" alt="image" src="https://github.com/valgeirb/nuxt-fathom/assets/1769417/a1a54b61-e5f6-418e-b37c-9b05d54fd032">

It tracks the pageview of the `/` path which is correct.

Then navigating to `/jobs/director-of-operations-wind-drone`:

<img width="943" alt="image" src="https://github.com/valgeirb/nuxt-fathom/assets/1769417/01e96727-0bf2-480d-9ab4-bff3dad017b6">

Note that it has passed exactly the same URL. Then we will navigate again to the homepage `/`:

<img width="785" alt="image" src="https://github.com/valgeirb/nuxt-fathom/assets/1769417/00ecb7c0-76b2-453f-b0e8-cbe50e3fe60a">

Here shows how it has passed the last url `/jobs/director-of-operations-wind-drone` instead of the new one `/`.

This PR solves the issue by ensuring that the URL tracked by the fathom client is the URL the user is navigating to by passing it to the `trackPageview` method. I have tested this many times but would love if someone could reproduce it too before merging.